### PR TITLE
Refactor release checking logic in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,25 +16,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if push is from a release branch merge
-        id: check_merge
+      - name: Check if push is from a release
+        id: check_release
         run: |
           # Get the most recent commit
-          COMMIT_MSG=$(git log -1 --pretty=format:"%s")
-          echo "Last commit message: $COMMIT_MSG"
+          COMMIT_TITLE=$(git log -1 --pretty=format:"%s")
+          echo "Last commit title: $COMMIT_TITLE"
           
-          # Check if the commit is a merge from a Release branch
-          if [[ "$COMMIT_MSG" == Merge\ pull\ request* && "$COMMIT_MSG" == *from\ Release/* ]]; then
-            echo "is_release_merge=true" >> $GITHUB_OUTPUT
-            echo "This is a merge from a Release branch"
+          # Check if the commit title starts with Release/ or contains Release/
+          if [[ "$COMMIT_TITLE" == Release/* || "$COMMIT_TITLE" == *"Release/"* ]]; then
+            echo "is_release=true" >> $GITHUB_OUTPUT
+            echo "This is a release commit"
           else
-            echo "is_release_merge=false" >> $GITHUB_OUTPUT
-            echo "This is not a merge from a Release branch"
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "This is not a release commit"
           fi
 
       - name: Get version
         id: get_version
-        if: steps.check_merge.outputs.is_release_merge == 'true'
+        if: steps.check_release.outputs.is_release == 'true'
         run: |
           # Extract version from version.json file
           VERSION=$(jq -r '.version' version.json)
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        if: steps.check_merge.outputs.is_release_merge == 'true'
+        if: steps.check_release.outputs.is_release == 'true'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
           prerelease: false
 
       - name: Update major version tag
-        if: steps.check_merge.outputs.is_release_merge == 'true'
+        if: steps.check_release.outputs.is_release == 'true'
         run: |
           # Extract major version
           MAJOR_VERSION=$(echo "${{ env.VERSION }}" | cut -d. -f1)


### PR DESCRIPTION
Replaced "release branch merge" checks with direct checks for commit titles containing "Release/" for better clarity and maintainability. Updated related conditional statements accordingly.