### PR TITLE
Simplify release workflow by removing unused release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,26 +15,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Check if push is from a release
-        id: check_release
-        run: |
-          # Get the most recent commit
-          COMMIT_TITLE=$(git log -1 --pretty=format:"%s")
-          echo "Last commit title: $COMMIT_TITLE"
-          
-          # Check if the commit title starts with Release/ or contains Release/
-          if [[ "$COMMIT_TITLE" == Release/* || "$COMMIT_TITLE" == *"Release/"* ]]; then
-            echo "is_release=true" >> $GITHUB_OUTPUT
-            echo "This is a release commit"
-          else
-            echo "is_release=false" >> $GITHUB_OUTPUT
-            echo "This is not a release commit"
-          fi
-
       - name: Get version
         id: get_version
-        if: steps.check_release.outputs.is_release == 'true'
         run: |
           # Extract version from version.json file
           VERSION=$(jq -r '.version' version.json)
@@ -50,7 +32,6 @@ jobs:
 
       - name: Create Release
         id: create_release
-        if: steps.check_release.outputs.is_release == 'true'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +44,6 @@ jobs:
           prerelease: false
 
       - name: Update major version tag
-        if: steps.check_release.outputs.is_release == 'true'
         run: |
           # Extract major version
           MAJOR_VERSION=$(echo "${{ env.VERSION }}" | cut -d. -f1)


### PR DESCRIPTION
Removed unnecessary "Check if push is from a release" step and its related conditionals. Streamlined workflow for efficiency.